### PR TITLE
Maximize window to available workarea

### DIFF
--- a/src/TitleBar/components/Bar.js
+++ b/src/TitleBar/components/Bar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import electron from 'electron';
 import ThemeContext from '../Theme';
 
 const styles = {
@@ -15,7 +16,21 @@ const styles = {
   }
 };
 
+const currentWindow = electron.remote.getCurrentWindow();
 class Bar extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleDoubleClick = this.handleDoubleClick.bind(this);
+  }
+
+  handleDoubleClick(e) {
+    let { isWin } = this.props;
+    if (!isWin) {
+      let bounds = electron.screen.getPrimaryDisplay().workArea;
+      currentWindow.setBounds(bounds, true);
+    }
+  }
+
   render() {
     let props = this.props;
     let theme = this.context;
@@ -27,6 +42,7 @@ class Bar extends React.Component {
     return (
       <div
         style={{ ...styles.Bar, height, backgroundColor, color, borderBottom }}
+        onDoubleClick={this.handleDoubleClick}
       >
         {props.children}
       </div>
@@ -35,5 +51,9 @@ class Bar extends React.Component {
 }
 
 Bar.contextType = ThemeContext;
+
+Bar.defaultProps = {
+  isWin: false
+}
 
 export default Bar;

--- a/src/TitleBar/index.js
+++ b/src/TitleBar/index.js
@@ -26,7 +26,8 @@ class TitleBar extends Component {
     onMinimizeClick,
     onMaximizeClick,
     disableMaximize,
-    disableMinimize
+    disableMinimize,
+    onBarDoubleClick
   }) => {
     switch (platform) {
       case 'win32': // win32
@@ -74,7 +75,9 @@ class TitleBar extends Component {
         );
       default:
         return (
-          <Bar>
+          <Bar
+            onDoubleClick={onBarDoubleClick}
+          >
             <ResizeHandle top />
             <ResizeHandle left />
             {
@@ -164,7 +167,8 @@ TitleBar.defaultProps = {
   onTitleClick: () => {},
   onCloseClick: () => {},
   onMinimizeClick: () => {},
-  onMaximizeClick: () => {}
+  onMaximizeClick: () => {},
+  onBarDoubleClick: () => {}
 };
 
 export default TitleBar;


### PR DESCRIPTION
(MacOS only): When double clicking the titlebar the window will resize to fill up the workable area