### PR TITLE
Added Menu Item Icons

### DIFF
--- a/example/src/utils/menus.js
+++ b/example/src/utils/menus.js
@@ -16,6 +16,7 @@ export const defaultTemplate = [
       {
         id: '2',
         label: 'Sub Menu',
+        icon: 'https://www.gstatic.com/images/branding/product/1x/keep_48dp.png',
         submenu: [
           {
             label: 'Color Submenu',
@@ -41,7 +42,8 @@ export const defaultTemplate = [
             ]
           },
           {
-            label: 'Random 2'
+            label: 'Random 2',
+            icon: require('../assets/images/icon.png')
           },
           {
             label: 'Random 3',
@@ -80,6 +82,7 @@ export const defaultTemplate = [
       },
       {
         id: '3',
+        icon: require('../assets/images/icon.png'),
         label: 'Arguments',
         click: (item, win, e) => { console.log(item, win, e); }
       },

--- a/src/TitleBar/MenuBar/MenuButton/index.js
+++ b/src/TitleBar/MenuBar/MenuButton/index.js
@@ -53,7 +53,7 @@ export default class MenuButton extends Component {
 
     return (
       <div
-        styles={styles.Wrapper}
+        style={styles.Wrapper}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         onMouseOver={onMouseOver}

--- a/src/TitleBar/MenuBar/MenuList/MenuItem/index.js
+++ b/src/TitleBar/MenuBar/MenuList/MenuItem/index.js
@@ -39,6 +39,12 @@ const styles = {
     width: '100%',
     border: 'none',
     height: 1
+  },
+  Icon: {
+    width: '100%',
+    height: '100%',
+    backgroundSize: 'contain',
+    backgroundPosition: 'center'
   }
 }
 
@@ -163,6 +169,15 @@ class MenuItem extends Component {
       statusIcon = menuItem.checked ? radioChecked : radioUnchecked;
     } else if (menuItem.type === 'checkbox') {
       statusIcon = menuItem.checked ? checked : unchecked;
+    } else if (menuItem.icon) {
+      statusIcon = (
+        <div
+          style={{
+            ...styles.Icon,
+            backgroundImage: `url(${menuItem.icon})`
+          }}
+        />
+      );
     }
 
     return (

--- a/src/TitleBar/MenuBar/MenuList/MenuItem/styles.css
+++ b/src/TitleBar/MenuBar/MenuList/MenuItem/styles.css
@@ -1,6 +1,7 @@
 .StatusIcon {
   width: 12px;
   height: 12px;
+  flex-shrink: 0;
 }
 
 .StatusIcon svg {


### PR DESCRIPTION
* set `icon` property on menu item to be a url or require statement of an image to display it alongside menu item labels

example
```js
{
    label: 'Arguments',
    icon: require('../assets/images/icon.png')
}
```

<img width="1070" alt="screen shot 2018-12-22 at 11 34 42 pm" src="https://user-images.githubusercontent.com/14713485/50381697-482c9400-0642-11e9-8eb7-6bf93d6e5b65.png">
