### PR TITLE
`disableMaximize`, `disableMinimize`

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -61,12 +61,13 @@ npm start
     "normal": {
       "default": {
         "color": "inherit",
-        "background": "transparent"
+        "background": "transparent",
       },
       "hover": {
         "color": "#fff",
         "background": "rgba(255,255,255,0.3)"
-      }
+      },
+      "disabledOpacity": 0.3
     },
     "close": {
       "default": {

--- a/src/title-bar/theme/index.ts
+++ b/src/title-bar/theme/index.ts
@@ -99,7 +99,8 @@ const controlsTheme = {
       hover: <ColorMap>{
         color: '#fff',
         background: 'rgba(255,255,255,0.3)'
-      }
+      },
+      disabledOpacity: 0.3
     },
     close: <ControlButton>{
       default: <ColorMap>{
@@ -118,6 +119,7 @@ const controlsTheme = {
       hover: <ColorMap>{
         background: 'rgba(0, 0, 0, 0.1)'
       },
+      disabledOpacity: 0.3
     },
   },
   linux: <ControlsTheme>{

--- a/src/title-bar/typings/index.ts
+++ b/src/title-bar/typings/index.ts
@@ -77,6 +77,7 @@ export interface BarTheme {
 export interface ControlButton {
   default?: ColorMap;
   hover?: ColorMap;
+  disabledOpacity?: number;
 }
 
 export type ControlsLayout = 'right' | 'left';
@@ -250,4 +251,5 @@ export interface WindowButtonProps {
   close: boolean;
   controls: Required<ControlsTheme>;
   platform: Platform;
+  isDisabled: boolean;
 }

--- a/src/title-bar/window-controls/button.tsx
+++ b/src/title-bar/window-controls/button.tsx
@@ -8,7 +8,8 @@ const WindowButton = ({
   onClick,
   close,
   controls,
-  platform
+  platform,
+  isDisabled
 }: WindowButtonProps) => {
   const [ref, hovering] = useHover<HTMLDivElement>();
   let config: ColorMap;
@@ -32,9 +33,10 @@ const WindowButton = ({
           color: config.color,
           background: config.background,
           borderRadius: controls.borderRadius,
-          border: controls.border
+          border: controls.border,
+          opacity: (isDisabled && !close) ? controls.normal.disabledOpacity : 1
         }}
-        onClick={onClick}
+        onClick={!isDisabled ? onClick : () => {}}
       >
         {children}
       </div>

--- a/src/title-bar/window-controls/button.tsx
+++ b/src/title-bar/window-controls/button.tsx
@@ -16,7 +16,7 @@ const WindowButton = ({
   if (close) {
     config = hovering ? controls.close.hover! : controls.close.default!;
   } else {
-    config = hovering ? controls.normal.hover! : controls.normal.default!;
+    config = (hovering && !isDisabled) ? controls.normal.hover! : controls.normal.default!;
   }
 
   const width = platform === 'win32' ? '100%' : '20px';

--- a/src/title-bar/window-controls/index.tsx
+++ b/src/title-bar/window-controls/index.tsx
@@ -7,18 +7,17 @@ import WindowButton from './button';
 import { WindowControlsProps, ControlsTheme } from '../typings';
 
 const buttons = (isWin: boolean, onMinimize: () => void, onMaximize: () => void, onClose: () => void, disableMinimize: boolean, disableMaximize: boolean) => ([
-  {
+  ... !(disableMaximize && disableMinimize) ? [{
     type: 'minimize',
     onClick: onMinimize,
     icon: <MinimizeIcon isWin={isWin} />,
     disabled: disableMinimize
-  },
-  {
+  }, {
     type: 'maximize',
     onClick: onMaximize,
     icon: <MaximizeIcon isWin={isWin} />,
     disabled: disableMaximize
-  },
+  }] : [],
   {
     type: 'close',
     onClick: onClose,
@@ -41,7 +40,12 @@ const WindowControls = ({
     controls
   } = useContext(ThemeContext);
   const isWin = platform === 'win32';
-  const width = platform === 'win32' ? '146px' : '120px';
+  let width: string;
+  if (disableMaximize && disableMinimize) {       // hide minimize and maximize button
+    width = platform === 'win32' ? '48px' : '40px';
+  } else {
+    width = platform === 'win32' ? '146px' : '120px';
+  }
   return (
     <div
       className={styles.ControlsWrapper}

--- a/src/title-bar/window-controls/index.tsx
+++ b/src/title-bar/window-controls/index.tsx
@@ -6,21 +6,24 @@ import { ThemeContext } from '../theme';
 import WindowButton from './button';
 import { WindowControlsProps, ControlsTheme } from '../typings';
 
-const buttons = (isWin: boolean, onMinimize: () => void, onMaximize: () => void, onClose: () => void) => ([
+const buttons = (isWin: boolean, onMinimize: () => void, onMaximize: () => void, onClose: () => void, disableMinimize: boolean, disableMaximize: boolean) => ([
   {
     type: 'minimize',
     onClick: onMinimize,
-    icon: <MinimizeIcon isWin={isWin} />
+    icon: <MinimizeIcon isWin={isWin} />,
+    disabled: disableMinimize
   },
   {
     type: 'maximize',
     onClick: onMaximize,
-    icon: <MaximizeIcon isWin={isWin} />
+    icon: <MaximizeIcon isWin={isWin} />,
+    disabled: disableMaximize
   },
   {
     type: 'close',
     onClick: onClose,
-    icon: <CloseIcon isWin={isWin} />
+    icon: <CloseIcon isWin={isWin} />,
+    disabled: false
   }
 ])
 
@@ -28,6 +31,8 @@ const WindowControls = ({
   onMinimize,
   onMaximize,
   onClose,
+  disableMinimize,
+  disableMaximize,
   focused
 }: WindowControlsProps) => {
   const {
@@ -46,13 +51,14 @@ const WindowControls = ({
       }}
     >
       {
-        buttons(isWin, onMinimize!, onMaximize!, onClose!).map((b) => {
+        buttons(isWin, onMinimize!, onMaximize!, onClose!, disableMinimize!, disableMaximize!).map((b) => {
           return (
             <WindowButton
               key={b.type}
               platform={platform}
               close={b.type === 'close'}
               onClick={b.onClick}
+              isDisabled={b.disabled}
               controls={controls as Required<ControlsTheme>}
             >
               {b.icon}


### PR DESCRIPTION
@Cristian006 Noticed in the typing/API you meant to implement `disableMaximize` and `disableMinimize` - I went ahead and made those two functional. I took a look at the default styling in Electron and made it similar here - when disabled, the buttons don't have the handler bound and don't respond to hover.

Also, in line with the titlebar's default behavior in Electron, if both `minimizable` and `maximizable` were set as false, those two buttons are hid. I implemented that too. Let me know if the PR works, cheers!